### PR TITLE
fix: 字数实时提醒徽标被窗格左边缘截断（窄窗格下字数显示不全）

### DIFF
--- a/src/styles/features/word-count.css
+++ b/src/styles/features/word-count.css
@@ -53,7 +53,10 @@ body .markdown-source-view.mod-cm6 .cm-editor.webnovel-show-gutter .cm-scroller 
 	display: flex;
 	align-items: center;
 	/* Rely on internal zero-width character for perfect text baseline vertical centering */
-	justify-content: flex-end;
+	/* 让徽标从 Gutter 左缘向右生长：这一侧永远位于编辑器可视区内。
+		若改为 flex-end（向左溢出），徽标会越出窗格左边缘被 overflow 裁掉，
+		窄窗格（内容未居中的 --file-margins-x 只有 32px）下必然显示不全。 */
+	justify-content: flex-start;
 	width: 0px;
 	/* Remove all hardcoded heights, rely on content to expand, absolutely match current editor line height */
 	overflow: visible;
@@ -78,8 +81,8 @@ body .markdown-source-view.mod-cm6 .cm-editor.webnovel-show-gutter .cm-scroller 
 	z-index: 99;
 	pointer-events: none;
 	/* Avoid blocking mouse clicks in the left area */
-	/* Push left relative to wrapper, fine-tune to align with text line */
-	margin-right: 12px;
+	/* 徽标左缘与 Gutter 左缘对齐，向右生长；旧值 margin-right: 12px 会把徽标整体推到 Gutter 左侧 */
+	margin-right: 0;
 	/* Remove margin-top, hand over completely to flex-center for auto scheduling */
 }
 


### PR DESCRIPTION
## 问题

「字数实时提醒」的徽标在**窄窗格**下会被窗格左边缘裁掉，字数显示不全。4 位以上的字数（`2000字` 约 46px 宽）在双栏布局里必然只剩末尾一小截，用户看到的就是 `0字`：

| 修复前（620px 窗格） | 修复后 |
| --- | --- |
| ![修复前](https://raw.githubusercontent.com/OCDcreator/obsidian-webnovel-assistant/doc/word-count-badge-evidence/assets/word-count-badge-clipped-before.png) | ![修复后](https://raw.githubusercontent.com/OCDcreator/obsidian-webnovel-assistant/doc/word-count-badge-evidence/assets/word-count-badge-fixed-after.png) |

触发条件很常见：主区域分两栏（每栏约 620–700px）+ 左右侧栏。窗格够宽时不会出现，因为 Obsidian 会把正文居中（`.cm-sizer { max-width: var(--file-line-width); margin: auto }`），那段居中留白刚好给徽标腾出了位置 —— 这大概是问题一直没被发现的原因。

## 原因

徽标用的是「零宽 Gutter + 向左溢出」的画法：

- `.webnovel-word-count-gutter { width: 0 }`（不占位、不推正文）
- `.webnovel-word-count-marker-wrapper { width: 0; justify-content: flex-end }`
- `.webnovel-word-count-marker { margin-right: 12px }`

于是徽标被整体推到 Gutter 左侧、也就是编辑器左内边距（`--file-margins-x`，默认 32px）里。插件已经用 `overflow: visible` 覆盖掉了 CodeMirror 自身的 `.cm-gutter { overflow: hidden }`，但更外层的裁剪绕不过去：

- Obsidian 的 `.workspace-leaf { overflow: hidden }`、`.workspace-leaf-content { overflow: hidden }`
- `.workspace-leaf-content[data-type='markdown'] .view-content { padding: 0; overflow: hidden }`

**窗格左边缘就是裁剪线。** 当窗格宽度不足 `--file-line-width(700px) + 2×padding` 时内容不再居中、没有居中留白，左侧可用空间只剩 32px，再减去 `margin-right: 12px` 只剩 20px —— 任何 3 位以上的字数都放不下，必然被裁。

## 修改

`src/styles/features/word-count.css`，只改 2 个属性，让徽标从 Gutter 左缘**向右**生长（这一侧永远位于编辑器可视区内）：

```diff
-	justify-content: flex-end;
+	justify-content: flex-start;

-	margin-right: 12px;
+	margin-right: 0;
```

没有动任何 JS；Gutter 依旧是零宽，徽标不占位、不会推动正文排版，任何主题/字号/窗格宽度下都不会再被裁。

宽窗格下的前后对比（左侧留白场景保持不变，只是徽标改为占据行号列的位置）：

![宽窗格对比](https://raw.githubusercontent.com/OCDcreator/obsidian-webnovel-assistant/doc/word-count-badge-evidence/assets/word-count-badge-wide-compare.png)

## 验证

- 用 Obsidian 官方 `app.css`（从 `obsidian.asar` 解包得到）+ CodeMirror 基础样式 + 本仓库构建产物搭了静态渲染环境，**修复前能精确复现**上面的截图（窄窗格只剩 `0字`），修复后完整显示；宽窗格、以及关闭行号的场景也做了前后对比。
- 仓库自带检查全绿：`tsc --noEmit`、`eslint --max-warnings=0`、`stylelint` + `css-audit`、`obsidian-audit`、`i18n-audit`，以及 `vitest`（56 files / 967 tests）全部通过。

## 想请作者权衡的取舍

改成向右生长后，徽标会占用行号列的位置：

- **开启行号**时：出现徽标的那一行，行号会被徽标盖住（默认间隔 2000 字，每章大约 1–3 行）。
- **关闭行号**（Obsidian 默认）时：徽标会压住该行开头的缩进、乃至第一个字的少量笔画。

![关闭行号场景](https://raw.githubusercontent.com/OCDcreator/obsidian-webnovel-assistant/doc/word-count-badge-evidence/assets/word-count-badge-no-line-numbers.png)

我的判断是「字数完整可读」比「个别行的行号被占」更重要，所以这样改。如果你更希望行号完全不被遮挡，另一条路是保持贴行号左侧、由 JS 量测左侧可用空间后自适应决定（够宽就留在左侧留白、不够才右移），代价是要引入量测与 resize 监听；需要的话我可以按这个思路再提一版。

---

> PR 正文里的截图放在本 fork 的 `doc/word-count-badge-evidence` 分支（`assets/` 下，`.gitignore` 规定媒体文件只放这里），这样本 PR 的 diff 保持纯 CSS、不夹带二进制文件。该分支仅供说明用，合并时无需理会、可直接删除。
